### PR TITLE
Modified Dockerfile Enabling Successful Build of docker-latex

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,15 +1,41 @@
-FROM alpine:latest
+FROM    alpine:edge
 
-COPY test-sample.tex /tmp/test-sample.tex
+# Create container image with a default non-privileged user account.
+#
+#    docker build --pull -t docker-latex .
+#
+# Create temporary instance and generate a portable document format (PDF)
+# document fron the TeX file
+#
+#    docker run \
+#        --rm \
+#        --volume host_path:/home/publisher/work docker-latex \
+#        pdflatex -output-format=pdf -output-directory=work test-sample.tex
 
-RUN apk add -U make
-# poppler (found in edge/main repository) is a dependency for texlive
-RUN apk add -U --repository http://dl-3.alpinelinux.org/alpine/edge/main \
-    poppler
-# zziplib (found in edge/community repository) is a dependency to texlive-luatex
-RUN apk add -U --repository http://dl-3.alpinelinux.org/alpine/edge/community \
-    zziplib
-RUN apk add -U --repository http://dl-3.alpinelinux.org/alpine/edge/testing \
-    texlive-full
+RUN     echo "http://dl-cdn.alpinelinux.org/alpine/edge/testing" \
+        >> /etc/apk/repositories \
+        && apk --no-cache update upgrade
 
-RUN ln -s /usr/bin/mktexlsr /usr/bin/mktexlsr.pl
+# Install TeX Live and associated packages. After retrieving texlive-texmf for
+# the first time comment out wget to avoid downloading with each image build.
+RUN     apk --no-cache add icu-libs make poppler texlive-full xz zziplib \
+	&& wget http://ftp.math.utah.edu/pub/tex/historic/systems/texlive/2016/texlive-20160523b-texmf.tar.xz \
+        && tar -xJf texlive-20160523b-texmf.tar.xz \
+        && cp -r texlive-20160523-texmf/texmf-dist /usr/share \
+        && rm -rf texlive* \
+	&& apk fix texlive \
+	&& ln -s /usr/bin/mktexlsr /usr/bin/mktexlsr.pl
+
+# Create default unprivileged user account
+
+ENV     DC_USER publisher
+ENV     HOME /home/${DC_USER}
+
+RUN     adduser -D ${DC_USER} \
+        && mkdir ${HOME}/work \	
+        && chown -R ${DC_USER}:${DC_USER} ${HOME}
+
+USER    ${DC_USER}
+COPY    test-sample.tex ${HOME}/test-sample.tex
+VOLUME	${HOME}/work
+WORKDIR	${HOME}

--- a/README.md
+++ b/README.md
@@ -1,14 +1,14 @@
 # docker-latex
 
-**It seems that the texlive-full Alpine Linux package maybe broken, so this
-doesn't work rigt now.**
+This container came about because I ~~was~~am using [tianon/latex][] to build
+some LaTeX documents, but GitLab took a long time to pull the container, so I
+decided to attempt making a smaller version that will significantly improve CI
+build times. In addition, I also wanted to be able to use a Makefile for
+building.
 
-This container came about because I ~~was~~am using [tianon/latex][] to build some
-LaTeX documents, but GitLab took a long time to pull the container, so I decided
-to attempt making a smaller version that will significantly improve CI build
-times. In addition, I also wanted to be able to use a Makefile for building.
-
-This more lightweight version reduces the build time by about 4 minutes!
+After retrieving texlive-texmf for the first time comment out wget to avoid
+downloading for each image build. This more lightweight version reduces the
+build time compared to tianon/latex during subsequent builds.
 
 
 ## Usage
@@ -40,7 +40,10 @@ docker build --pull -t docker-latex .
 ### Compiling sample document
 
 ```sh
-docker run docker-latex pdflatex /tmp/test-sample.tex
+docker run --rm \
+    --volume host_path:/home/publisher/work \
+    docker-latex \
+    pdflatex -output-format=pdf -output-directory=work test-sample.tex
 ```
 
 


### PR DESCRIPTION
The Dockerfile has been modified to enable successful builds and the README.md has been updated. Alpine Linux branch: edge and repository: testing has been used instead of Alpine Linux branch: latest. The appropriate texlive-texmf file retrieved so that pdflatex can translate a LaTeX file into a PDF file as demonstrated by test-sample.tex. Created a default unprivileged user account and cleaned up Dockerfile.

REPOSITORY              TAG                 IMAGE ID            CREATED             SIZE
docker-latex            latest              c827cf1466f0        30 minutes ago      4.22 GB
